### PR TITLE
Add MobX state management

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,7 +177,6 @@ const  Home = observer(() => {
 
   useEffect(() => {
     setFilteredProjects(projects)
-
   }, [projects]);
 
   function searchData(searchValue: string) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,8 @@ import { NewProject, Project } from "@/types/types";
 import { useProjectListContext } from "@/context/ProjectListContext";
         
 import './style.scss'
+import { observer } from "mobx-react-lite";
+import ModelStore from "./stores/modelStore";
 
 // TODO: Create a new modal component?
 const CreateProjectModal: React.FC<{
@@ -163,13 +165,12 @@ const CreateProjectModal: React.FC<{
   )
 }
 
-export default function Home() {
+const  Home = observer(() => {
   const {
-    projects,
-    fetchProjects,
     createProject,
   } = useProjectListContext();
 
+  const projects = ModelStore.projects;
   const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
   const [openModal, setOpenModal] = useState<boolean>(false);
   const device = checkDeviceType();
@@ -200,7 +201,6 @@ export default function Home() {
 
   async function handleCreate(newProject: NewProject) {
     await createProject(newProject);
-    fetchProjects();
     setOpenModal(false)
   }
 
@@ -300,4 +300,6 @@ export default function Home() {
       </Container>
     </main>
   )
-}
+});
+
+export default Home;

--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -37,8 +37,7 @@ const EditProjectModal: React.FC<{
   const { currentProject, patchProject } = useProjectContext();
   const projectInfo = currentProject as Project;
 
-  const handleDataChange = (fieldName: string, value: string) => {
-    // @ts-ignore
+  const handleDataChange = (fieldName: keyof Project, value: string) => {
     projectInfo[fieldName] = value;
     patchProject(projectInfo);
   };

--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -33,24 +33,17 @@ const EditProjectModal: React.FC<{
   onConfirm: (updatedProject: Project) => void;
   project: Project;
 }> = observer(({ open, onConfirm, onClose, project }) => {
-  const [projectInfo, setProjectInfo] = useState<Project>(project);
+
+  const { currentProject, patchProject } = useProjectContext();
+  const projectInfo = currentProject as Project;
+
   const handleDataChange = (fieldName: string, value: string) => {
-    setProjectInfo((prevData) => ({
-      ...prevData,
-      [fieldName]: value,
-    }));
+    // @ts-ignore
+    projectInfo[fieldName] = value;
+    patchProject(projectInfo);
   };
 
   const handleClose = () => {
-    setProjectInfo({
-      id: "",
-      name: "",
-      homeownerName: "",
-      homeownerPhone: "",
-      homeownerEmail: "",
-      homeownerAddress: "",
-      createdAt: "",
-    });
     onClose();
   }
 
@@ -161,7 +154,7 @@ const EditProjectModal: React.FC<{
   );
 });
 
-const DataCollection = () => {
+const DataCollection = observer(() => {
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [deleteModal, setDeleteModal] = useState<boolean>(false);
   const [value, setValue] = useState<number>(0); //TODO: rename this please
@@ -207,7 +200,7 @@ const DataCollection = () => {
           open={openModal}
           project={currentProject}
           onClose={() => setOpenModal(false)}
-          onConfirm={handleUpdateProject}
+          onConfirm={(info) => {handleUpdateProject(info); setOpenModal(false)}}
           aria-labelledby="modal-title"
           aria-describedby="modal-description"
         />
@@ -306,6 +299,6 @@ const DataCollection = () => {
       </Container>
     </>
   )
-}
+})
 
 export default DataCollection

--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -23,6 +23,7 @@ import './style.scss'
 import DeleteProjectModal from "@/components/Modals/DeleteProject";
 import { useProjectListContext } from "@/context/ProjectListContext";
 import { useRouter } from "next/navigation";
+import { observer } from "mobx-react-lite";
 
 // TODO: Definitely transform this into a component
 
@@ -31,7 +32,7 @@ const EditProjectModal: React.FC<{
   onClose: () => void;
   onConfirm: (updatedProject: Project) => void;
   project: Project;
-}> = ({ open, onConfirm, onClose, project }) => {
+}> = observer(({ open, onConfirm, onClose, project }) => {
   const [projectInfo, setProjectInfo] = useState<Project>(project);
   const handleDataChange = (fieldName: string, value: string) => {
     setProjectInfo((prevData) => ({
@@ -158,7 +159,7 @@ const EditProjectModal: React.FC<{
       </div>
     </Modal>
   );
-};
+});
 
 const DataCollection = () => {
   const [openModal, setOpenModal] = useState<boolean>(false);

--- a/app/stores/modelStore.ts
+++ b/app/stores/modelStore.ts
@@ -1,9 +1,12 @@
 import { NewProject, Project } from '@/types/types';
-import { makeAutoObservable } from 'mobx';
+import { computed, makeAutoObservable, observable } from 'mobx';
 import customFetch from '../helpers/customFetch';
 
+// Note: Today, just using 1 ModelStore to store all state for all objects for simplicity
+// In the future we may want to split by Object type.
 export class _ModelStore {
-    projectsByID: Map<string, Project> = new Map();
+
+    projectsByID: Map<string, Project> = observable.map(new Map());
 
     constructor() {
         makeAutoObservable(this);
@@ -82,7 +85,25 @@ export class _ModelStore {
         }
     }
 
-    // TODO: Need to build in auto update detection.
+    // TODO: Need to build offline path for this guy
+    patchProject = async (project: Project) => {
+        try {
+            const response = await customFetch(`/api/projects/${project.id}`, {
+             method: 'PATCH',
+             body: JSON.stringify(project),
+            });
+    
+            if (!response.ok) {
+            throw new Error('Failed to update project');
+            }
+
+            const found = this.getProject(project.id);
+            Object.assign(found, project);
+    
+        } catch (error) {
+            console.error('Error updating project:', error);
+        }
+    }
 }
 
 const ModelStore = new _ModelStore();

--- a/app/stores/modelStore.ts
+++ b/app/stores/modelStore.ts
@@ -1,0 +1,75 @@
+import { NewProject, Project } from '@/types/types';
+import { makeAutoObservable } from 'mobx';
+import customFetch from '../helpers/customFetch';
+
+export class _ModelStore {
+    projects: Project[] = [];
+
+    constructor() {
+        makeAutoObservable(this);
+    }
+
+    loadProjects = async () => {
+        console.log('Fetching project')
+        try {
+          const response = await customFetch("/api/projects/");
+          if (!response.ok) {
+            throw new Error('Failed to fetch projects');
+          }
+    
+          const data = await response.json();
+          const projectsWithFormattedDate = data.map((project: Project) => ({
+            ...project,
+            createdAt: new Date(project.createdAt).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            }),
+          }));
+    
+          this.projects = projectsWithFormattedDate;
+        } catch (error) {
+          console.error('Error fetching projects:', error);
+        }
+    }
+
+    // TODO: Need to build offline path for this guy
+    createProject = async (newProject: NewProject) => {
+        try {
+            const response = await customFetch("/api/projects/", {
+              method: 'POST',
+              body: JSON.stringify(newProject),
+            });
+      
+            if (!response.ok) {
+              throw new Error('Failed to create project');
+            }
+
+            await this.loadProjects();
+          } catch (error) {
+            console.error('Error creating project:', error);
+          }
+    }
+
+    // TODO: Need to build offline path for this guy
+    deleteProject = async (projectId: string) => {
+        try {
+          const response = await customFetch(`/api/projects/${projectId}`, {
+            method: 'DELETE',
+          });
+    
+          if (!response.ok) {
+            throw new Error('Failed to delete project');
+          }
+    
+          await this.loadProjects();
+        } catch (error) {
+          console.error('Error deleting project:', error);
+        }
+    }
+
+    // TODO: Need to build in auto update detection.
+}
+
+const ModelStore = new _ModelStore();
+export default ModelStore;

--- a/app/stores/modelStore.ts
+++ b/app/stores/modelStore.ts
@@ -1,5 +1,5 @@
 import { NewProject, Project } from '@/types/types';
-import { computed, makeAutoObservable, observable } from 'mobx';
+import { makeAutoObservable, observable } from 'mobx';
 import customFetch from '../helpers/customFetch';
 
 // Note: Today, just using 1 ModelStore to store all state for all objects for simplicity

--- a/context/ProjectContext.tsx
+++ b/context/ProjectContext.tsx
@@ -32,12 +32,7 @@ export const ProjectProvider: React.FC<{ children: ReactNode }> = observer(({ ch
   }
 
   async function patchProject(project: Project) {
-    const projectFound = ModelStore.getProject(project.id);
-    if (!projectFound) {
-      throw new Error("Project not found");
-    }
-
-    Object.assign(projectFound, project);
+    return ModelStore.patchProject(project);
   }
 
   const contextValue: ProjectContextProps = {

--- a/context/ProjectContext.tsx
+++ b/context/ProjectContext.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
 import { NewProject, Project } from "@/types/types";
 import customFetch from "@/app/helpers/customFetch";
+import ModelStore from "@/app/stores/modelStore";
+import { observer } from "mobx-react-lite";
 
 interface ProjectContextProps {
   currentProject: Project | null;
@@ -18,35 +20,24 @@ export const useProjectContext = () => {
   return context;
 };
 
-export const ProjectProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+export const ProjectProvider: React.FC<{ children: ReactNode }> = observer(({ children }) => {
   const [currentProject, setCurrentProject] = useState<Project | null>(null);
 
   async function fetchProject(projectId: string) {
-    try {
-      const response = await customFetch(`/api/projects/${projectId}`);
-      if (!response.ok) {
-        throw new Error("Failed to fetch project");
-      }
-
-      const data = await response.json();
-      setCurrentProject(data);
-    } catch (error) {
-      console.error("Error fetching project:", error);
+    const project = await ModelStore.getProject(projectId);
+    if (!project) {
+         throw new Error("Failed to fetch project");
     }
+    setCurrentProject(project);
   }
 
   async function patchProject(project: Project) {
-    try {
-      const response = await customFetch(`/api/project${project.id}`, {
-        method: 'PATCH',
-        body: JSON.stringify(project),
-      })
-
-      const data = await response.json();
-      setCurrentProject(data);
-    } catch (error) {
-      console.error("Error updating project:", error);
+    const projectFound = ModelStore.getProject(project.id);
+    if (!projectFound) {
+      throw new Error("Project not found");
     }
+
+    Object.assign(projectFound, project);
   }
 
   const contextValue: ProjectContextProps = {
@@ -60,4 +51,4 @@ export const ProjectProvider: React.FC<{ children: ReactNode }> = ({ children })
       {children}
     </ProjectContext.Provider>
   );
-};
+});

--- a/context/ProjectListContext.tsx
+++ b/context/ProjectListContext.tsx
@@ -2,13 +2,10 @@
 
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { NewProject, Project } from "@/types/types";
-
-import customFetch from "@/app/helpers/customFetch";
+import ModelStore from "@/app/stores/modelStore";
+import { observer } from "mobx-react-lite";
 
 interface ProjectListContextProps {
-  projects: Project[];
-  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
-  fetchProjects: () => Promise<void>;
   createProject: (newProject: NewProject) => Promise<void>;
   deleteProject: (projectId: string) => Promise<void>;
 }
@@ -27,75 +24,21 @@ export const useProjectListContext = () => {
 
 export const ProjectListProvider: React.FC<{
   children: React.ReactNode
-}> = ({ children }) => {
-
-  const [projects, setProjects] = useState<Project[]>([]);
+}> = observer(({ children }) => {
 
   useEffect(() => {
-    fetchProjects();
+    ModelStore.loadProjects();
   }, []);
 
-  async function fetchProjects() {
-    console.log('Fetching project')
-    try {
-      const response = await customFetch("/api/projects/");
-      if (!response.ok) {
-        throw new Error('Failed to fetch projects');
-      }
-
-      const data = await response.json();
-      const projectsWithFormattedDate = data.map((project: Project) => ({
-        ...project,
-        createdAt: new Date(project.createdAt).toLocaleDateString("en-US", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        }),
-      }));
-
-      setProjects(projectsWithFormattedDate);
-    } catch (error) {
-      console.error('Error fetching projects:', error);
-    }
-  }
-
   async function createProject(newProject: NewProject) {
-    try {
-      const response = await customFetch("/api/projects/", {
-        method: 'POST',
-        body: JSON.stringify(newProject),
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to create project');
-      }
-
-      await fetchProjects();
-    } catch (error) {
-      console.error('Error creating project:', error);
-    }
+    return ModelStore.createProject(newProject);
   }
 
   async function deleteProject(projectId: string) {
-    try {
-      const response = await customFetch(`/api/projects/${projectId}`, {
-        method: 'DELETE',
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to delete project');
-      }
-
-      await fetchProjects();
-    } catch (error) {
-      console.error('Error deleting project:', error);
-    }
+    return ModelStore.deleteProject(projectId);
   }
 
   const contextValue: ProjectListContextProps = {
-    projects,
-    setProjects,
-    fetchProjects,
     createProject,
     deleteProject,
   };
@@ -105,4 +48,4 @@ export const ProjectListProvider: React.FC<{
       {children}
     </ProjectListContext.Provider>
   );
-};
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "dayjs": "^1.11.10",
     "eslint": "8.50.0",
     "eslint-config-next": "13.5.2",
+    "mobx": "^6.10.2",
+    "mobx-react-lite": "^4.0.5",
     "next": "^13.5.4",
     "next-pwa": "^5.6.0",
     "postcss": "8.4.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4140,6 +4140,18 @@ mlly@^1.2.0, mlly@^1.4.0:
     pkg-types "^1.0.3"
     ufo "^1.3.0"
 
+mobx-react-lite@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-4.0.5.tgz#e2cb98f813e118917bcc463638f5bf6ea053a67b"
+  integrity sha512-StfB2wxE8imKj1f6T8WWPf4lVMx3cYH9Iy60bbKXEs21+HQ4tvvfIBZfSmMXgQAefi8xYEwQIz4GN9s0d2h7dg==
+  dependencies:
+    use-sync-external-store "^1.2.0"
+
+mobx@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.10.2.tgz#96e123deef140750360ca9a5b02a8b91fbffd4d9"
+  integrity sha512-B1UGC3ieK3boCjnMEcZSwxqRDMdzX65H/8zOHbuTY8ZhvrIjTUoLRR2TP2bPqIgYRfb3+dUigu8yMZufNjn0LQ==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"


### PR DESCRIPTION
* Create a mobx store called `ModelStore` for storing/updating data models from API -- (this will also be the layer at which some smart offline batching happens before serviceworker in the future)
* Re-implemented the current projectlist /project page to use the new mobX store instead of react state
* See in-line comments for more details about how to use


tl;dr on how to use MobX:
1. Wrap components you want to see updates in using `observer`
2. Add properties on the MobX store class, i.e. `_ModelStore` and the changes to them will be auto-reflected
