### PR TITLE
Make a change to the photos picker

### DIFF
--- a/app/project/[id]/plans/Upgrades/Photos.tsx
+++ b/app/project/[id]/plans/Upgrades/Photos.tsx
@@ -53,6 +53,7 @@ const Photos: React.FC<PlanPhotoProps> = observer(({ plan, project }) => {
       }
       const newPlan = { ...plan }
       newPlan.planDetails = JSON.stringify(newPlanDetails)
+      setPlanDetails(newPlanDetails);
       await ModelStore.patchPlan(plan.projectId, newPlan)
     }
   }


### PR DESCRIPTION
Explanation for the fix:

* The root plans page is not observing the MobX object for plan and instead using react state, so ModelStore.<mutation> methods aren't being propagated down. This is a temporary fix but at some point we need to make the plans experience react to the ModelStore changes