### PR TITLE
Add versioning support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,11 +7,10 @@ import { ClerkProvider } from '@clerk/nextjs'
 import './globals.scss'
 // import ducklingTheme from "./style/theme/theme" // Here whenever we decide to move to our own theme
 
-const roboto = Roboto({ subsets: ['latin'],
+const roboto = Roboto({
+  subsets: ['latin'],
   display: 'swap',
-  weight: [
-  '300', '400', '500', '700', '900'
-  ]
+  weight: ['300', '400', '500', '700', '900'],
 })
 
 export const metadata: Metadata = {

--- a/app/utils/versioning.ts
+++ b/app/utils/versioning.ts
@@ -1,0 +1,26 @@
+import packageJson from '../../package.json'
+
+export const VersionManager = {
+  onVersionUpdate: (callback: () => void) => {
+    const storedVersion = VersionManager._getStoredVersion()
+    const currentVersion = VersionManager.getCurrentVersion()
+    if (storedVersion !== currentVersion) {
+      callback()
+      VersionManager._setStoredVersion(currentVersion)
+    }
+  },
+
+  getCurrentVersion: () => {
+    return packageJson.version ?? 'unknown'
+  },
+
+  _getStoredVersion: () => {
+    return localStorage.getItem('appVersion')
+  },
+
+  _setStoredVersion: (version: string) => {
+    localStorage.setItem('appVersion', version)
+  },
+}
+
+export default VersionManager


### PR DESCRIPTION
Adds support for clearing caches + offline data whenever "version" changes.

Did not implement auto-versioning for now. Just requires adding "npm version patch" automation to on merge/commit 